### PR TITLE
Fix outdated jaas auth required module issue

### DIFF
--- a/files/default/jaas-loginmodule.conf
+++ b/files/default/jaas-loginmodule.conf
@@ -1,5 +1,5 @@
 RDpropertyfilelogin {
-org.mortbay.jetty.plus.jaas.spi.PropertyFileLoginModule required
+org.eclipse.jetty.plus.jaas.spi.PropertyFileLoginModule required
 debug="true"
 file="/etc/rundeck/realm.properties";
 };


### PR DESCRIPTION
I tried to ran the cookbook, the rundeck service is up and running. However, I cannot login the system. It always tells me

> Invalid username and password.

I took hours to investigate why it is so, and eventually found that one line in `jaas-loginmodule.conf`

```
org.mortbay.jetty.plus.jaas.spi.PropertyFileLoginModule required
```

differs from [installed one](https://github.com/rundeck/rundeck/blob/development/packaging/debroot/etc/rundeck/jaas-loginmodule.conf)

```
org.eclipse.jetty.plus.jaas.spi.PropertyFileLoginModule required
```

this leads authentication never pass, but yet I didn't see any complaining in the log. I am not a Java expert, I cannot tell why it is so, but anyway, by using the correct login module, I can login without an issue now.
