### PR TITLE
sets default jdk version to 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ to run the partial_search for.
 
 ## java.rb
 
+* `node['java']['jdk_version']` - Sets the version of jdk, defaults to `7`
+
 * `node['rundeck']['java']['enable_jmx']` - Defines a set of flags in order to enable JMX monitoring on the
   Rundeck installation
 

--- a/attributes/java.rb
+++ b/attributes/java.rb
@@ -17,6 +17,9 @@
 # limitations under the License.
 #
 
+# Staring from version 2.5.0-1-GA rundeck requires jdk version 7
+default['java']['jdk_version'] = '7'
+
 default['rundeck']['java']['enable_jmx'] = false
 default['rundeck']['java']['allocated_memory'] = "#{(node['memory']['total'].to_i * 0.5 ).floor / 1024}m"
 default['rundeck']['java']['thread_stack_size'] = '256k'


### PR DESCRIPTION
Staring from version 2.5.0-1-GA rundeck requires jdk version 7