### PR TITLE
Allow custom parameters option to the global groovy configuration file.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -86,3 +86,4 @@ default['rundeck']['rdbms']['port'] = "3306"
 # Custom properties hashes
 default['rundeck']['custom_properties']['framework'] = Hash.new
 default['rundeck']['custom_properties']['project'] = Hash.new
+default['rundeck']['custom_properties']['global'] = Hash.new

--- a/templates/default/rundeck-config.groovy.erb
+++ b/templates/default/rundeck-config.groovy.erb
@@ -36,3 +36,7 @@ grails.mail.password = "<%= node['rundeck']['mail']['password'] %>"
 grails.mail.props += ["mail.smtp.starttls.enable":"true", "mail.smtp.port": <%= node['rundeck']['mail']['port'] %>]
 <% end %>
 
+# Custom global options
+<% node['rundeck']['custom_properties']['global'].each do |key, value| -%>
+<%= key %> = "<%= value %>"
+<% end %>

--- a/templates/default/rundeck-config.groovy.erb
+++ b/templates/default/rundeck-config.groovy.erb
@@ -36,7 +36,7 @@ grails.mail.password = "<%= node['rundeck']['mail']['password'] %>"
 grails.mail.props += ["mail.smtp.starttls.enable":"true", "mail.smtp.port": <%= node['rundeck']['mail']['port'] %>]
 <% end %>
 
-# Custom global options
+// Custom global options
 <% node['rundeck']['custom_properties']['global'].each do |key, value| -%>
 <%= key %> = "<%= value %>"
 <% end %>


### PR DESCRIPTION
Just like for framework and project, added ability so that global groovy config file can also have custom parameters so that we can customize new features such as [project storage type.](http://rundeck.org/docs/administration/project-setup.html#project-definitions)